### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy to GitHub Pages
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/lorettarehm/AgileGamifAI/security/code-scanning/1](https://github.com/lorettarehm/AgileGamifAI/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the deployment step (`JamesIves/github-pages-deploy-action@v4`), the workflow likely requires `contents: write` to push changes to the `gh-pages` branch. Other steps, such as `Checkout` and `Build`, do not require additional permissions.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`build-and-deploy`) to limit permissions to that job only. In this case, adding it at the root level is sufficient and ensures clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
